### PR TITLE
Make `PointAndClick` abstract & add wiping script

### DIFF
--- a/Assets/Scenes/CleanFloorTest.unity
+++ b/Assets/Scenes/CleanFloorTest.unity
@@ -370,7 +370,7 @@ GameObject:
   - component: {fileID: 753045249}
   - component: {fileID: 753045252}
   - component: {fileID: 753045251}
-  - component: {fileID: 753045250}
+  - component: {fileID: 753045253}
   m_Layer: 5
   m_Name: Left Window
   m_TagString: Untagged
@@ -398,18 +398,6 @@ RectTransform:
   m_AnchoredPosition: {x: -190, y: 193}
   m_SizeDelta: {x: 200, y: 410}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &753045250
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 753045248}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e044e2b01c5aaf344ba82d55a55db3f9, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &753045251
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -445,6 +433,18 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 753045248}
   m_CullTransparentMesh: 1
+--- !u!114 &753045253
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 753045248}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0ae4e0103104f7945966370c61f2369c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &949702386
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/CleanFloorWiping.cs
+++ b/Assets/Scripts/CleanFloorWiping.cs
@@ -1,0 +1,51 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+public class CleanFloorWiping : PointAndClick
+{
+    [Tooltip("How far you have to drag in order to wipe")]
+    [SerializeField] public float minWipeDistance = 50f;
+
+    private Vector2 _beginDragPos;
+
+    // Start is called before the first frame update
+    void Start()
+    {
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+    }
+
+    public override void OnBeginDrag(PointerEventData eventData)
+    {
+        base.OnBeginDrag(eventData);
+
+        // Keep track of where dragging began
+        _beginDragPos = eventData.position;
+    }
+
+    public override void OnDrag(PointerEventData eventData)
+    {
+        // Calculate distance dragged
+        Vector2 currDragPos = eventData.position;
+        float distance = CalculateDistance(_beginDragPos, currDragPos);
+
+        if(distance > minWipeDistance)
+        {
+            // If dragged over a certain distance, then execute logic
+            Debug.Log("Wiping " + gameObject.name);
+        }
+    }
+
+    // Distance formula: sqrt((x2 - x1)^2 + (y2 - y1)^2)
+    private float CalculateDistance(Vector2 start, Vector2 end)
+    {
+        float sqx = Mathf.Pow(end.x - start.x, 2);
+        float sqy = Mathf.Pow(end.y - start.y, 2);
+        return Mathf.Sqrt(sqx + sqy);
+    }
+}

--- a/Assets/Scripts/CleanFloorWiping.cs.meta
+++ b/Assets/Scripts/CleanFloorWiping.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0ae4e0103104f7945966370c61f2369c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/PointAndClick.cs
+++ b/Assets/Scripts/PointAndClick.cs
@@ -7,7 +7,7 @@ using UnityEngine.EventSystems;
 /// Will listen for Pointer events for the attached GameObject.
 /// GameObject must be a UI component (Image, RawImage, Text).
 /// </summary>
-public class PointAndClick : MonoBehaviour, IPointerEnterHandler, IPointerExitHandler, IPointerDownHandler,
+public abstract class PointAndClick : MonoBehaviour, IPointerEnterHandler, IPointerExitHandler, IPointerDownHandler,
     IPointerUpHandler, IPointerClickHandler, IBeginDragHandler, IDragHandler, IEndDragHandler
 {
     // TODO: Make class abstract and extendable for different types of game actions
@@ -22,7 +22,7 @@ public class PointAndClick : MonoBehaviour, IPointerEnterHandler, IPointerExitHa
     {
     }
 
-    public void OnPointerEnter(PointerEventData eventData)
+    public virtual void OnPointerEnter(PointerEventData eventData)
     {
         Debug.Log("Entered " + gameObject.name);
 
@@ -36,36 +36,36 @@ public class PointAndClick : MonoBehaviour, IPointerEnterHandler, IPointerExitHa
         // Change cursor to normal sprite
     }
 
-    public void OnPointerDown(PointerEventData eventData)
+    public virtual void OnPointerDown(PointerEventData eventData)
     {
         Debug.Log("Down " + gameObject.name);
     }
 
-    public void OnPointerUp(PointerEventData eventData)
+    public virtual void OnPointerUp(PointerEventData eventData)
     {
         Debug.Log("Up " + gameObject.name);
     }
 
-    public void OnPointerClick(PointerEventData eventData)
+    public virtual void OnPointerClick(PointerEventData eventData)
     {
         Debug.Log("Clicked " + eventData.pointerCurrentRaycast.gameObject.name);
 
         // Perform some game action depending on what GameObject it is
     }
 
-    public void OnBeginDrag(PointerEventData eventData)
+    public virtual void OnBeginDrag(PointerEventData eventData)
     {
         Debug.Log("Begin drag " + gameObject.name);
     }
 
-    public void OnDrag(PointerEventData eventData)
+    public virtual void OnDrag(PointerEventData eventData)
     {
         Debug.Log("Dragging " + gameObject.name);
 
         // Game logic related to dragging
     }
 
-    public void OnEndDrag(PointerEventData eventData)
+    public virtual void OnEndDrag(PointerEventData eventData)
     {
         Debug.Log("End drag " + gameObject.name);
     }


### PR DESCRIPTION
`PointAndClick` can now be extended for feature specific point-and-click logic. All pointer handlers can be overriden or extended to provide additional logic.

Closes #6 
Closes #8 

Getting closer to completing #2 